### PR TITLE
Breadcrumb change design and position

### DIFF
--- a/src/app/presentation/shop/layout/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/presentation/shop/layout/components/breadcrumb/breadcrumb.component.html
@@ -4,13 +4,13 @@
             <div class="col-xxl-12">
 
                 <div class="p-relative z-index-1">
-                    <h3 class="breadcrumb__title">{{breadCrumb[breadCrumb.length - 1].name}}</h3>
                     <div class="breadcrumb__list">
                         <span *ngFor="let value of breadCrumb; let last = last">
                             <a class="align-middle" [routerLink]="value.url">{{value.name}}</a>
                             <i *ngIf="!last" class="px-2 align-middle fa-sharp fa-regular fa-angle-right"></i>
                         </span>
                     </div>
+                    <h3 class="breadcrumb__title">{{breadCrumb[breadCrumb.length - 1].name}}</h3>
                 </div>
 
             </div>

--- a/src/app/presentation/shop/layout/components/breadcrumb/breadcrumb.component.scss
+++ b/src/app/presentation/shop/layout/components/breadcrumb/breadcrumb.component.scss
@@ -2,16 +2,17 @@
 
     &__title {
         font-weight: 500;
-        font-size: 28px;
+        font-size: 25px;
         line-height: 1;
-        margin-bottom: 6px;
     }
 
     &__list {
 
+        margin-bottom: 10px;
+
         & span {
             font-weight: 400;
-            font-size: 16px;
+            font-size: 15px;
             position: relative;
 
             &:last-child {


### PR DESCRIPTION
# Pull Request Description

This PR modifies the `Breadcrumb` component by changing the position of the page title and the breadcrumb, and adjusts the font sizes for better visual hierarchy and readability.

## Change Type

- [x] Improvement
- [x] UI/UX

## How Has This Been Tested?

1. Moved the `Breadcrumb` component above the page title.
2. Adjusted the font size of the `Breadcrumb` to 15 pixels.
3. Adjusted the font size of the page title to 25 pixels.
4. Verified that the layout displays correctly with the new positioning and font sizes.
5. Ensured that no new warnings or errors were introduced.

## Checklist

- [x] Code reviewed and functioning.
- [x] Application tested and runs correctly.
- [x] No new warnings.
- [x] Does not break existing tests.

## Additional Information

These changes enhance the visual hierarchy and readability of the page by appropriately positioning the `Breadcrumb` component and adjusting font sizes.

## Summary of Changes

### Breadcrumb Component

- Moved the `Breadcrumb` component above the page title.
- Changed the font size of the `Breadcrumb` to 15 pixels.
- Changed the font size of the page title to 25 pixels.

### Testing

- Verified that the `Breadcrumb` component displays above the page title as expected.
- Confirmed that the font sizes of the `Breadcrumb` and page title are correctly set to 15 pixels and 25 pixels, respectively.
- Ensured that no new warnings or errors were introduced.
- Checked that existing tests pass without issues.
