### PR TITLE
Breadcrumb component fixed

### DIFF
--- a/src/app/presentation/shop/home/home.routing.ts
+++ b/src/app/presentation/shop/home/home.routing.ts
@@ -6,12 +6,7 @@ import { HomeComponent } from "./home.component";
 const routes: Routes = [
     {
         path: '',
-        component: HomeComponent,
-        data: {
-            url: APP_ROUTES.HOME,
-            name: 'Inicio',
-            isActive: false
-        }
+        component: HomeComponent
     }
 ]
 

--- a/src/app/presentation/shop/layout/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/presentation/shop/layout/components/breadcrumb/breadcrumb.component.ts
@@ -31,6 +31,8 @@ export class BreadcrumbComponent implements OnInit {
 
         this.getRoutes().subscribe(response => {
 
+            this.initializeHome()
+
             const object: BreadCrumb = {
                 name: response['name'],
                 url: response['url'],
@@ -44,10 +46,18 @@ export class BreadcrumbComponent implements OnInit {
                 this.isActive = true
             }
 
-            if (!this.breadCrumb.find((element) => element.name == response['name'])) {
+            if (response['name'] !== 'Home') {
                 this.breadCrumb.push(object);
             }
         })
+    }
+
+    initializeHome() {
+        this.breadCrumb = [{
+            name: 'Home',
+            url: '/',
+            isActive: false
+        }];
     }
 
     getRoutes() {


### PR DESCRIPTION
# Pull Request Description

This PR modifies the `Breadcrumb` component to display only the home link and the current page, ensuring that no breadcrumb is shown on the home page. It adjusts the breadcrumb logic to dynamically reflect the user's current page.

## Change Type

- [x] Improvement
- [x] Bug fix

## How Has This Been Tested?

1. Modified the `Breadcrumb` component to display only the home link and the current page.
2. Ensured that no breadcrumb is displayed when on the home page.
3. Verified that the breadcrumb displays `Home` and the current page correctly for other pages such as `Store` and `Wishlist`.
4. Tested the breadcrumb on various pages to ensure it reflects the correct hierarchy (e.g., `Home > Wishlist` or `Home > Store`).
5. Confirmed that the changes work as expected without introducing any new issues.

## Checklist

- [x] Code reviewed and functioning.
- [x] Application tested and runs correctly.
- [x] No new warnings.
- [x] Does not break existing tests.

## Additional Information

These changes ensure that the breadcrumb component provides a clear and concise navigation path, improving the user experience by displaying the home link and the current page accurately.

## Summary of Changes

### Breadcrumb Component

- Modified to display only the home link and the current page.
- Ensured that no breadcrumb is shown on the home page.
- Adjusted breadcrumb logic to dynamically reflect the user's current page.

### Testing

- Verified that the breadcrumb component hides on the home page.
- Confirmed the correct breadcrumb display for other pages (e.g., `Home > Wishlist`, `Home > Store`).
- Ensured that no new warnings or errors were introduced.
- Checked that existing tests pass without issues.