### PR TITLE
Hide result of store component

### DIFF
--- a/src/app/presentation/shop/products/store/components/header-store/header-store.component.html
+++ b/src/app/presentation/shop/products/store/components/header-store/header-store.component.html
@@ -4,7 +4,7 @@
         <div class="col-xl-6 col-lg-6 col-md-6">
             <div class="shop-top-left d-flex align-items-center">
                 <div class="shop-top-result">
-                    <p>Showing 1–14 of 26 results</p>
+                    <!-- <p>Showing 1–14 of 26 results</p> -->
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# Pull Request Description

This PR comments out the line in the `Store` component that displayed the number of product results and how many products are currently being viewed. This is done to ensure only functional features are visible in the application.

## Change Type

- [x] Improvement
- [x] Temporary Fix

## How Has This Been Tested?

1. Commented out the line in the `Store` component that displayed product result counts.
2. Verified that the line is no longer visible in the application.
3. Ensured that no new warnings or errors were introduced.

## Checklist

- [x] Code reviewed and functioning.
- [x] Application tested and runs correctly.
- [x] No new warnings.
- [x] Does not break existing tests.

## Additional Information

This change temporarily hides non-functional features from the user interface, ensuring that only working elements are displayed. This will be revisited and re-enabled once the feature is fully functional.

## Summary of Changes

### Store Component

- Commented out the line displaying the number of product results and currently viewed products.

### Testing

- Verified that the commented-out line is no longer visible in the application.
- Ensured that no new warnings or errors were introduced.
- Checked that existing tests pass without issues.
